### PR TITLE
Fix: Hide Meetecho link button on mobile to give more space to the progress bar

### DIFF
--- a/src/components/footer/footer.jsx
+++ b/src/components/footer/footer.jsx
@@ -4,6 +4,7 @@ import MobileLayoutToggleButton from "./mobile-layout-toggle-button";
 import ThemeSelector from "./theme-selector";
 import VideoStreamSelector from "./video-stream-selector";
 import Logo from "./logo";
+import { useMediaQuery } from "react-responsive";
 
 // Styles
 import "./footer.scss";
@@ -21,6 +22,7 @@ function Footer({
   handleToggleComponents,
   sessionData,
 }) {
+  const isTabletOrMobile = useMediaQuery({ query: "(max-width: 1224px)" });
   return (
     <footer className="Footer section--wrapper">
       <VideoStreamSelector sessionData={sessionData} />
@@ -43,7 +45,7 @@ function Footer({
 
       <ThemeSelector />
 
-      <Logo />
+      {!isTabletOrMobile && <Logo />}
     </footer>
   );
 }


### PR DESCRIPTION
Fix: The new buttons to switch the video source from YouTube to Cloudflare made the time progress bar too packed on mobile devices. This PR removes the button with the link to the Meetecho website when in mobile mode, to give more space to the progress bar.